### PR TITLE
Retentive tags

### DIFF
--- a/src/lib/libcdt.c
+++ b/src/lib/libcdt.c
@@ -736,7 +736,6 @@ dax_tag_handle(dax_state *ds, tag_handle *h, char *str, int count)
     if(h == NULL || ds == NULL || str == NULL) {
         return ERR_ARG;
     }
-
     bzero(h, sizeof(tag_handle)); /* Initialize h */
     result = _dax_tag_handle(ds, h, str, strlen(str) + 1, count);
     if(result) {

--- a/src/lib/libdata.c
+++ b/src/lib/libdata.c
@@ -55,6 +55,7 @@ _cache_hit(dax_state *ds, tag_cnode *this, dax_tag *tag)
     tag->idx = this->idx;
     tag->type = this->type;
     tag->count = this->count;
+    tag->attr = this->attr;
 
     /* Bubble up:
      'after' is set to the node that we swap with
@@ -133,7 +134,6 @@ check_cache_name(dax_state *ds, char *name, dax_tag *tag)
             return ERR_NOTFOUND;
         }
     }
-
     _cache_hit(ds, this, tag);
 
     return 0;
@@ -177,6 +177,7 @@ cache_tag_add(dax_state *ds, dax_tag *tag)
     new->idx = tag->idx;
     new->type = tag->type;
     new->count = tag->count;
+    new->attr = tag->attr;
     //--print_cache();
 
     return 0;

--- a/src/lib/libdax.h
+++ b/src/lib/libdax.h
@@ -55,6 +55,7 @@ typedef struct Tag_Cnode {
     tag_index idx;
     unsigned int type;
     unsigned int count;
+    unsigned int attr;
     struct Tag_Cnode *next;
     struct Tag_Cnode *prev;
     char name[DAX_TAGNAME_SIZE + 1];

--- a/src/opendax.h
+++ b/src/opendax.h
@@ -115,6 +115,7 @@ extern "C" {
 #define ERR_READONLY  -27 /* Resource is read only */
 #define ERR_WRITEONLY -28 /* Resource is write only */
 #define ERR_NOTIMPLEMENTED -29 /* Function not implemented */
+#define ERR_FILE_CLOSED   -30 /* File is not open */
 
 /* Module configuration flags */
 #define CFG_ARG_NONE        0x00 /* No Arguments */

--- a/src/opendax.h
+++ b/src/opendax.h
@@ -241,6 +241,7 @@ struct dax_tag {
     tag_index idx;        /* Unique tag index */
     tag_type type;        /* Tags data type */
     unsigned int count;   /* The number of items in the tag array */
+    unsigned int attr;
     char name[DAX_TAGNAME_SIZE + 1];
 };
 

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -27,7 +27,8 @@ add_executable(tagserver server.c
                          mapping.c
                          virtualtag.c
                          groups.c
-                         atomic.c)
+                         atomic.c
+                         retain.c)
 target_link_libraries(tagserver ${LUA_LIBRARIES})
 target_link_libraries(tagserver pthread)
 if(CMAKE_BUILD_TYPE MATCHES Debug)

--- a/src/server/message.c
+++ b/src/server/message.c
@@ -499,14 +499,15 @@ msg_tag_get(dax_message *msg)
         result = tag_get_name((char *)&msg->data[1], &tag);
         xlog(LOG_MSG | LOG_VERBOSE, "Tag Get Message from %d for name '%s'", msg->fd, (char *)msg->data);
     }
-    size = strlen(tag.name) + 13;
+    size = strlen(tag.name) + 17;
     buff = alloca(size);
     if(buff == NULL) result = ERR_ALLOC;
     if(!result) {
         *((u_int32_t *)&buff[0]) = tag.idx;
         *((u_int32_t *)&buff[4]) = tag.type;
         *((u_int32_t *)&buff[8]) = tag.count;
-        strcpy(&buff[12], tag.name);
+        *((u_int32_t *)&buff[12]) = tag.attr;
+        strcpy(&buff[16], tag.name);
         _message_send(msg->fd, MSG_TAG_GET, buff, size, RESPONSE);
         xlog(LOG_MSG | LOG_VERBOSE, "Returning tag - '%s':0x%X to module %d",tag.name, tag.idx, msg->fd);
     } else {

--- a/src/server/retain.c
+++ b/src/server/retain.c
@@ -169,7 +169,7 @@ _write_tag_def(int index, size_t offset) {
 
     name_size = strlen(_db[index].name);
     flags = 0x00;
-    data_size = type_size(_db[index].type) * _db[index].count;
+    data_size = tag_get_size(index);
     lseek(_fd, offset, SEEK_SET);
     tmp = 0;
     write(_fd, &tmp, 4); /* pointer to next tag, 0 = we are the last one*/
@@ -225,7 +225,7 @@ int
 ret_tag_write(int index) {
     u_int32_t offset, data_size;
 
-    data_size = type_size(_db[index].type) * _db[index].count;
+    data_size = tag_get_size(index);
     offset = _db[index].ret_file_pointer;
     lseek(_fd, offset, SEEK_SET);
     write(_fd, _db[index].data, data_size);

--- a/src/server/retain.c
+++ b/src/server/retain.c
@@ -1,0 +1,153 @@
+/*  OpenDAX - An open source data acquisition and control system
+ *  Copyright (c) 2021 Phil Birkelbach
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+ *  Source code file for tag retention functions
+ */
+
+#include <common.h>
+#include "func.h"
+#include "tagbase.h"
+#include <sys/stat.h>
+#include <fcntl.h>
+
+extern _dax_tag_db *_db;
+
+static int _fd;
+static u_int16_t _version;
+static u_int32_t _last_type_pointer;
+static u_int32_t _last_tag_pointer;
+//static u_int32_t _next_offset;
+
+
+int
+ret_init(char *filename) {
+    int result;
+    char buff[8];
+
+    xlog(LOG_MINOR, "Setting up Tag Retention");
+    if(filename == NULL) {
+        filename = "retentive.db";
+    }
+    _fd = open(filename, O_RDWR);
+    if(_fd < 0) {
+        /* If the file does not exist we will try to create it */
+        if(errno == ENOENT) {
+            _fd = open(filename, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
+            if(_fd < 0) {
+                xerror("Unable to create Retention File, %s - %s", filename, strerror);
+                _fd = 0;
+                return ERR_GENERIC;
+            }
+            result = write(_fd, "DAXRET\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00", 16);
+            if(result != 16) {
+                xerror("Error Writing to Retention File");
+                _fd=0;
+                return ERR_GENERIC;
+            }
+            return 0;
+        } else { /* Some other error opening the file */
+            xerror("Error Opening Retention File, %s - %s",filename, strerror(errno));
+            return ERR_GENERIC;
+        }
+    }
+    /* If we make it this far we should have the file open */
+    result = read(_fd, buff, 8);
+    if(result != 8) {
+        xerror("Error reading file signature");
+        _fd = 0;
+        return ERR_GENERIC;
+    }
+    if(strncmp("DAXRET", buff, 6) != 0) {
+        xerror("File signature doesn't match");
+        _fd = 0;
+        return ERR_GENERIC;
+    }
+    _version = (buff[6]<<8) | buff[7];
+
+    if(_version != 1) {
+        xerror("Wrong File Version");
+        _fd = 0;
+        return ERR_GENERIC;
+    }
+    /* If we get here then all is good */
+    /* TODO: Do the thing you do */
+    return 0;
+}
+
+static int
+_write_tag(int index, size_t offset) {
+    unsigned char name_size, flags;
+    u_int32_t data_size, tmp;
+
+    name_size = strlen(_db[index].name);
+    flags = 0x00;
+    data_size = type_size(_db[index].type) * _db[index].count;
+    lseek(_fd, offset, SEEK_SET);
+    tmp = 0;
+    write(_fd, &tmp, 4); /* pointer to next tag, 0 = we are the last one*/
+    write(_fd, &data_size, 4); /* size of the data area */
+    write(_fd, &name_size, 1); /* size of the tag name */
+    write(_fd, &flags, 1); /* flag byte */
+    write(_fd, _db[index].name, name_size);
+    write(_fd, _db[index].data, data_size);
+    /* This points to the offset in the file where we'll write this tags data */
+    _db[index].ret_file_pointer = offset + 10 + name_size;
+
+    return 0; /* TODO: Handle errors */
+}
+
+int
+ret_add_tag(int index) {
+    u_int32_t offset;
+
+    xlog(LOG_MINOR, "Adding Retained Tag at index %d", index);
+    /* TODO: Implement retaining custom data type tags */
+    if(IS_CUSTOM(_db[index].type)) return ERR_NOTIMPLEMENTED;
+    if(_fd == 0) return ERR_FILE_CLOSED;
+    offset = lseek(_fd, 0, SEEK_END); /* We're writing to the end no matter what */
+    if(_last_tag_pointer == 0) { /* This is our first tag */
+        lseek(_fd, 12, SEEK_SET); /* first tag pointer */
+        write(_fd, &offset, sizeof(offset));
+        _write_tag(index, offset);
+        _last_tag_pointer = offset;
+    } else {
+        _write_tag(index, offset);
+        lseek(_fd, _last_tag_pointer, SEEK_SET); /* Seek to the last tag */
+        /* Write the offset to the tag we just added to the previous tag */
+        write(_fd, &offset, 4);
+        _last_tag_pointer = offset;
+    }
+    return 0;
+}
+
+int
+ret_tag_write(int index) {
+    u_int32_t offset, data_size;
+
+    data_size = type_size(_db[index].type) * _db[index].count;
+    offset = _db[index].ret_file_pointer;
+    lseek(_fd, offset, SEEK_SET);
+    write(_fd, _db[index].data, data_size);
+    return 0;
+}
+
+
+int
+ret_close(void) {
+    if(_fd) close(_fd);
+    return 0;
+}

--- a/src/server/retain.h
+++ b/src/server/retain.h
@@ -1,0 +1,31 @@
+/*  OpenDAX - An open source data acquisition and control system
+ *  Copyright (c) 2021 Phil Birkelbach
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+ *  Header file for tag retention functions
+ */
+
+
+#ifndef __RETAIN_H
+#define __RETAIN_H
+
+int ret_init(char *filename);
+int ret_add_tag(int index);
+int ret_tag_write(int index);
+int ret_close(void);
+
+
+#endif /* !__RETAIN_H */

--- a/src/server/retain.h
+++ b/src/server/retain.h
@@ -22,8 +22,11 @@
 #ifndef __RETAIN_H
 #define __RETAIN_H
 
+#define RET_FLAG_DELETED 0x01
+
 int ret_init(char *filename);
 int ret_add_tag(int index);
+int ret_del_tag(int index);
 int ret_tag_write(int index);
 int ret_close(void);
 

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -20,6 +20,7 @@
 #include "options.h"
 #include "message.h"
 #include "tagbase.h"
+#include "retain.h"
 #include "func.h"
 #include <pthread.h>
 #include <syslog.h>
@@ -56,6 +57,8 @@ main(int argc, const char *argv[])
     result = msg_setup();    /* This creates and sets up the message sockets */
     if(result) xerror("msg_setup() returned %d", result);
     initialize_tagbase(); /* initialize the tag name database */
+    /* TODO: Add retention filename from configuration */
+    ret_init(NULL);
     /* Start the message handling thread */
     if(pthread_create(&message_thread, NULL, (void *)&messagethread, NULL)) {
         xfatal("Unable to create message thread");

--- a/src/server/tagbase.c
+++ b/src/server/tagbase.c
@@ -584,6 +584,7 @@ tag_get_name(char *name, dax_tag *tag)
         tag->idx = i;
         tag->type = _db[i].type;
         tag->count = _db[i].count;
+        tag->attr = _db[i].attr;
         strcpy(tag->name, _db[i].name);
         return 0;
     }
@@ -604,6 +605,7 @@ tag_get_index(int index, dax_tag *tag)
         tag->idx = index;
         tag->type = _db[index].type;
         tag->count = _db[index].count;
+        tag->attr = _db[index].attr;
         strcpy(tag->name, _db[index].name);
         return 0;
     }

--- a/src/server/tagbase.h
+++ b/src/server/tagbase.h
@@ -98,6 +98,7 @@ typedef struct {
     u_int8_t *data;
     u_int8_t *omask;        /* Override mask pointer */
     u_int8_t *odata;        /* Override data pointer */
+    u_int32_t ret_file_pointer; /* Pointer to the data area of the tag retention file */
 } _dax_tag_db;
 
 typedef struct {

--- a/tests/PythonTests/test_handles.py
+++ b/tests/PythonTests/test_handles.py
@@ -114,7 +114,7 @@ class TestHandles_LoopTests(unittest.TestCase):
         self.server = subprocess.Popen([testconfig.tagserver_file,
                                         "-C",
                                         "tests/config/tagserver_basic.conf"],
-                                        stdout=subprocess.DEVNULL
+#                                        stdout=subprocess.DEVNULL
                                         )
         time.sleep(0.1)
         x = self.server.poll()

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -62,6 +62,7 @@ foreach(file ${files})
   add_executable(${TESTNAME} ${FILENAME} ${SERVER_SOURCE_DIR}/tagbase.c
                                          ${SERVER_SOURCE_DIR}/func.c
                                          ${SERVER_SOURCE_DIR}/events.c
+                                         ${SERVER_SOURCE_DIR}/retain.c
                                          ${SERVER_SOURCE_DIR}/mapping.c
                                          ${SERVER_SOURCE_DIR}/virtualtag.c
   )
@@ -77,6 +78,7 @@ add_executable(groups_test groups_test.c ${SERVER_SOURCE_DIR}/groups.c
                                          ${SERVER_SOURCE_DIR}/tagbase.c
                                          ${SERVER_SOURCE_DIR}/func.c
                                          ${SERVER_SOURCE_DIR}/events.c
+                                         ${SERVER_SOURCE_DIR}/retain.c
                                          ${SERVER_SOURCE_DIR}/mapping.c
                                          ${SERVER_SOURCE_DIR}/virtualtag.c
   )

--- a/tests/library/CMakeLists.txt
+++ b/tests/library/CMakeLists.txt
@@ -132,3 +132,8 @@ add_executable(library_retention_basic libtest_retention_basic.c libtest_common.
 target_link_libraries(library_retention_basic dax)
 add_test(library_retention_basic library_retention_basic)
 set_tests_properties(library_retention_basic PROPERTIES TIMEOUT 10)
+
+add_executable(library_blank_tagname libtest_blank_tagname.c libtest_common.c)
+target_link_libraries(library_blank_tagname dax)
+add_test(library_blank_tagname library_blank_tagname)
+set_tests_properties(library_blank_tagname PROPERTIES TIMEOUT 10)

--- a/tests/library/CMakeLists.txt
+++ b/tests/library/CMakeLists.txt
@@ -127,3 +127,8 @@ add_executable(library_override_get libtest_override_get.c libtest_common.c)
 target_link_libraries(library_override_get dax)
 add_test(library_override_get library_override_get)
 set_tests_properties(library_override_get PROPERTIES TIMEOUT 10)
+
+add_executable(library_retention_basic libtest_retention_basic.c libtest_common.c)
+target_link_libraries(library_retention_basic dax)
+add_test(library_retention_basic library_retention_basic)
+set_tests_properties(library_retention_basic PROPERTIES TIMEOUT 10)

--- a/tests/library/libtest_blank_tagname.c
+++ b/tests/library/libtest_blank_tagname.c
@@ -1,0 +1,77 @@
+/*  OpenDAX - An open source data acquisition and control system
+ *  Copyright (c) 2021 Phil Birkelbach
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+/*
+ *  This test creates a single queue and checks that it works properly
+ */
+
+#include <common.h>
+#include <opendax.h>
+#include <signal.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include "libtest_common.h"
+
+
+int
+do_test(int argc, char *argv[])
+{
+    dax_state *ds;
+    int result = 0;
+    tag_handle h;
+    dax_dint temp, n;
+
+    ds = dax_init("test");
+    dax_init_config(ds, "test");
+
+    dax_configure(ds, argc, argv, CFG_CMDLINE);
+    result = dax_connect(ds);
+    if(result) {
+        return -1;
+    }
+    result = 0;
+    result += dax_tag_add(ds, &h, "TEST1", DAX_DINT | DAX_QUEUE, 1, 0);
+    result += dax_tag_add(ds, &h, "TEST2", DAX_DINT | DAX_QUEUE, 1, 0);
+    result += dax_tag_add(ds, &h, "TEST3", DAX_DINT | DAX_QUEUE, 1, 0);
+    result += dax_tag_add(ds, &h, "TEST4", DAX_DINT | DAX_QUEUE, 1, 0);
+    if(result) return result;
+
+    result += dax_tag_handle(ds, &h, "TEST1", 0);
+    result += dax_tag_handle(ds, &h, "TEST2", 0);
+    result += dax_tag_handle(ds, &h, "TEST3", 0);
+    result += dax_tag_handle(ds, &h, "TEST4", 0);
+    if(result) return result;
+    /* This should fail */
+    result = dax_tag_handle(ds, &h, "", 0);
+    if(result != ERR_NOTFOUND) {
+        printf("Looks like we duplicated the error\n");
+        return -1;
+    }
+    return 0;
+}
+
+/* main inits and then calls run */
+int
+main(int argc, char *argv[])
+{
+    if(run_test(do_test, argc, argv)) {
+        exit(-1);
+    } else {
+        exit(0);
+    }
+}

--- a/tests/library/libtest_common.c
+++ b/tests/library/libtest_common.c
@@ -45,7 +45,9 @@ run_test(int (testfunc(int argc, char **argv)), int argc, char **argv) {
         result=testfunc(argc, argv);
         kill(pid, SIGINT);
         if( waitpid(pid, &status, 0) != pid )
+            unlink("retentive.db");
             return status;
     }
+    unlink("retentive.db");
     return result;
 }

--- a/tests/library/libtest_retention_basic.c
+++ b/tests/library/libtest_retention_basic.c
@@ -29,7 +29,7 @@
 
 
 int
-do_test(int argc, char *argv[])
+test_one(int argc, char *argv[])
 {
     dax_state *ds;
     int result = 0;
@@ -46,19 +46,49 @@ do_test(int argc, char *argv[])
     }
     result = 0;
     result += dax_tag_add(ds, &h, "TEST1", DAX_DINT, 1, TAG_ATTR_RETAIN);
+    result += dax_tag_add(ds, &h, "TEST2", DAX_DINT, 1, TAG_ATTR_RETAIN);
     temp = 0xAABBCCDD;
     result = dax_write_tag(ds, h, &temp);
 
     return result;
 }
 
-/* main inits and then calls run */
+int
+test_two(int argc, char *argv[])
+{
+    dax_state *ds;
+    int result = 0;
+    tag_handle h;
+    dax_dint temp, n;
+
+    ds = dax_init("test");
+    dax_init_config(ds, "test");
+
+    dax_configure(ds, argc, argv, CFG_CMDLINE);
+    result = dax_connect(ds);
+    if(result) {
+        return -1;
+    }
+    result = 0;
+    result += dax_tag_add(ds, &h, "TEST1", DAX_DINT, 1, TAG_ATTR_RETAIN);
+    result += dax_tag_add(ds, &h, "TEST2", DAX_DINT, 1, TAG_ATTR_RETAIN);
+    result = dax_read_tag(ds, h, &temp);
+    if(temp != 0xAABBCCDD) return -1;
+
+    return result;
+}
+
+
 int
 main(int argc, char *argv[])
 {
-    if(run_test(do_test, argc, argv)) {
+    if(run_test(test_one, argc, argv)) {
         exit(-1);
     } else {
-        exit(0);
+        if(run_test(test_two, argc, argv)) {
+            exit(-1);
+        } else {
+            exit(0);
+        }
     }
 }

--- a/tests/library/libtest_retention_basic.c
+++ b/tests/library/libtest_retention_basic.c
@@ -1,0 +1,64 @@
+/*  OpenDAX - An open source data acquisition and control system
+ *  Copyright (c) 2021 Phil Birkelbach
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+/*
+ *  Tests the basic function of the tag retention functions
+ */
+
+#include <common.h>
+#include <opendax.h>
+#include <signal.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include "libtest_common.h"
+
+
+int
+do_test(int argc, char *argv[])
+{
+    dax_state *ds;
+    int result = 0;
+    tag_handle h;
+    dax_dint temp, n;
+
+    ds = dax_init("test");
+    dax_init_config(ds, "test");
+
+    dax_configure(ds, argc, argv, CFG_CMDLINE);
+    result = dax_connect(ds);
+    if(result) {
+        return -1;
+    }
+    result = 0;
+    result += dax_tag_add(ds, &h, "TEST1", DAX_DINT, 1, TAG_ATTR_RETAIN);
+    temp = 0xAABBCCDD;
+    result = dax_write_tag(ds, h, &temp);
+
+    return result;
+}
+
+/* main inits and then calls run */
+int
+main(int argc, char *argv[])
+{
+    if(run_test(do_test, argc, argv)) {
+        exit(-1);
+    } else {
+        exit(0);
+    }
+}


### PR DESCRIPTION
This is the basic tag retention feature.  If a tag is given the 'retain' attribute then it will be written to a file and all writes will be stored in that file so that the next time the server starts up that tag will be created and the data restored.